### PR TITLE
Defer icon loading

### DIFF
--- a/src/BladeFeatherIconsServiceProvider.php
+++ b/src/BladeFeatherIconsServiceProvider.php
@@ -9,10 +9,12 @@ class BladeFeatherIconsServiceProvider extends ServiceProvider
 {
     public function boot()
     {
-        $this->app->make(Factory::class)->add('feather-icons', [
-            'path' => __DIR__ . '/../resources/svg',
-            'prefix' => 'feathericon',
-        ]);
+        $this->callAfterResolving(Factory::class, function (Factory $factory) {
+            $factory->add('feather-icons', [
+                'path' => __DIR__ . '/../resources/svg',
+                'prefix' => 'feathericon',
+            ]);
+        });
 
         if ($this->app->runningInConsole()) {
             $this->publishes([


### PR DESCRIPTION
These changes will defer the icon loading until the factory has actually been resolved. This is also the new recommended way for packages to integrate with Blade Icons. No breaking changes, the previous way will still work.